### PR TITLE
fix(editor): check only editor input:invalid

### DIFF
--- a/assets/js/app/common.js
+++ b/assets/js/app/common.js
@@ -68,7 +68,7 @@ $(document).ready(function() {
      ** When a field from another group is invalid, show it.
      */
     $('#editor button[type="submit"]').click(function() {
-        $('input:invalid').each(function() {
+        $('#editor input:invalid').each(function() {
             // Find the tab-pane that this element is inside, and get the id
             var $closest = $(this).closest('.tab-pane');
             var id = $closest.attr('id');


### PR DESCRIPTION
The fix is for the issue https://github.com/bolt/core/issues/3488

The solution is to check only input in #editor, otherwise the global search field is find first