### PR TITLE
fix(form): allow html p and span in first character

### DIFF
--- a/templates/_macro/_macro.html.twig
+++ b/templates/_macro/_macro.html.twig
@@ -105,8 +105,10 @@
     'id':     Is a string
 #}
 {% macro generatePrefix(prefix, id) %}{% apply spaceless %}
-    {% if prefix and not (prefix starts with '<p' or prefix starts with '<span' or prefix starts with '<div') %}
+    {% if prefix and not (prefix starts with '<div') %}
         <div id="{{ id ~ '_prefix' }}" class="form--helper">{{ prefix|markdown }}</div>
+    {% else %}
+        {{ prefix|markdown }}
     {% endif %}
 {% endapply %}{% endmacro %}
 
@@ -116,7 +118,9 @@
     'id':      Is a string
 #}
 {% macro generatePostfix(postfix, id) %}{% apply spaceless %}
-    {% if postfix and not (postfix starts with '<p' or postfix starts with '<span' or postfix starts with '<div') %}
+    {% if postfix and not (postfix starts with '<div') %}
         <div id="{{ id ~ '_postfix' }}" class="form--helper">{{ postfix|markdown }}</div>
+    {% else %}
+        {{ prefix|markdown }}
     {% endif %}
 {% endapply %}{% endmacro %}


### PR DESCRIPTION
The fix is for the issue https://github.com/bolt/core/issues/3489

I don't understand why is not authorized :thinking: 